### PR TITLE
Create secretobjectdtot to deserialization of secret data into strongly typed objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Vault, and more.
 - **Custom Providers**: Easily extend with your own secret provider implementations
 - **Provider Order Configuration**: Specify the order in which providers are executed for secret retrieval using
   configuration properties
+- **Type Conversion for Secrets**: Retrieve secrets by key and origin, converting the value to the specified type for seamless integration with your application.
 
 ## Installation
 
@@ -178,7 +179,7 @@ spring:
 
 ## Examples
 
-Accessing Secrets in Code using SecretsManagerService
+### Accessing Secrets in Code using SecretsManagerService
 
 ```java
 public class MyService {
@@ -198,6 +199,39 @@ public class MyService {
         // Getting secret value or failure, only for AWS Secrets Manager
         SecretDTO secretDTO = secretsManagerService.getOrFailure(Origin.AWS, "my-secret-key");
     }
+}
+```
+
+### Retrieving a Secret by Key and Origin with Type Conversion
+
+You can retrieve a secret by its key and origin and convert its value to a specific type using the `SecretsManagerService`. Here's an example:
+
+```java
+import io.github.open_source_lfernandes.spring_secret_starter.dto.SecretDTO;
+import io.github.open_source_lfernandes.spring_secret_starter.enums.Origin;
+import io.github.open_source_lfernandes.spring_secret_starter.service.SecretsManagerService;
+
+public class MyService {
+
+  private final SecretsManagerService secretsManagerService;
+
+  public MyService(SecretsManagerService secretsManagerService) {
+    this.secretsManagerService = secretsManagerService;
+  }
+
+  public MyCustomType getCustomSecret() {
+    String key = "my-secret-key";
+    Origin origin = Origin.AWS_SECRETS_MANAGER;
+
+    return secretsManagerService.get(origin, key, MyCustomType.class);
+  }
+}
+
+class MyCustomType {
+  private String field1;
+  private int field2;
+
+  // Getters and setters
 }
 ```
 

--- a/src/main/java/io/github/open_source_lfernandes/spring_secret_starter/configuration/SecretsManagerServiceAutoConfiguration.java
+++ b/src/main/java/io/github/open_source_lfernandes/spring_secret_starter/configuration/SecretsManagerServiceAutoConfiguration.java
@@ -1,10 +1,13 @@
 package io.github.open_source_lfernandes.spring_secret_starter.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.open_source_lfernandes.spring_secret_starter.exceptions.NoneSecretProviderException;
 import io.github.open_source_lfernandes.spring_secret_starter.properties.SecretsProperties;
 import io.github.open_source_lfernandes.spring_secret_starter.service.SecretsManagerService;
 import io.github.open_source_lfernandes.spring_secret_starter.service.providers.AbstractSecretsProvider;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,12 +25,14 @@ import static java.util.Objects.isNull;
 @RequiredArgsConstructor
 @Configuration
 @EnableConfigurationProperties(SecretsProperties.class)
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class SecretsManagerServiceAutoConfiguration {
 
     /**
      * The list of secrets providers.
      */
-    private final List<AbstractSecretsProvider> providers;
+    List<AbstractSecretsProvider> providers;
+    ObjectMapper objectMapper;
 
     /**
      * Creates a SecretsManagerService bean if there are any providers available.
@@ -38,7 +43,7 @@ public class SecretsManagerServiceAutoConfiguration {
         if (isNull(providers) || providers.isEmpty())
             throw new NoneSecretProviderException("No Secret Provider Could Be Instantiate! Check your properties/yml file!");
         providers.sort(Comparator.comparingInt(AbstractSecretsProvider::getOrder));
-        return new SecretsManagerService(providers);
+        return new SecretsManagerService(providers, objectMapper);
     }
 
 }

--- a/src/main/java/io/github/open_source_lfernandes/spring_secret_starter/messages/Messages.java
+++ b/src/main/java/io/github/open_source_lfernandes/spring_secret_starter/messages/Messages.java
@@ -10,6 +10,10 @@ import lombok.Getter;
 public enum Messages {
 
     /**
+     * Error message for when the type is null.
+     */
+    TYPE_CANNOT_BE_NULL("Type cannot be null"),
+    /**
      * Error message for when the secret value is not found.
      */
     JSON_PARSE_SECRET_VALUE_ERROR("Error parsing secret value from JSON"),

--- a/src/test/java/io/github/open_source_lfernandes/spring_secret_starter/service/providers/SecretsProviderAwsTest.java
+++ b/src/test/java/io/github/open_source_lfernandes/spring_secret_starter/service/providers/SecretsProviderAwsTest.java
@@ -7,9 +7,8 @@ import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.open_source_lfernandes.spring_secret_starter.dto.SecretDTO;
 import io.github.open_source_lfernandes.spring_secret_starter.enums.Origin;
+import io.github.open_source_lfernandes.spring_secret_starter.utils.faker.Credential;
 import io.github.open_source_lfernandes.spring_secret_starter.utils.JsonUtils;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -17,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 
-import java.io.Serializable;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -87,10 +85,4 @@ class SecretsProviderAwsTest {
         assertEquals(Optional.empty(), secretsProviderAws.get("wrong-key"));
     }
 
-    @Data
-    @AllArgsConstructor
-    private static class Credential implements Serializable {
-        String username;
-        String password;
-    }
 }

--- a/src/test/java/io/github/open_source_lfernandes/spring_secret_starter/service/providers/SecretsProviderVaultTest.java
+++ b/src/test/java/io/github/open_source_lfernandes/spring_secret_starter/service/providers/SecretsProviderVaultTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 })
 @EnableConfigurationProperties(SecretsProperties.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class SecretsProviderVaultTest {
+class SecretsProviderVaultTest {
 
     @Container
     private static final VaultContainer<?> vaultContainer = new VaultContainer<>("hashicorp/vault:latest")
@@ -62,7 +62,7 @@ public class SecretsProviderVaultTest {
     }
 
     @Test
-    public void shouldReturnSecretFromVaultCorrectly() {
+    void shouldReturnSecretFromVaultCorrectly() {
         Optional<SecretDTO> optionalSecretDTO = secretsProviderVault.get(key);
 
         assertNotNull(optionalSecretDTO);
@@ -71,12 +71,26 @@ public class SecretsProviderVaultTest {
     }
 
     @Test
-    public void shouldReturnEmptyOptionalWhenSecretNotFound() {
+    void shouldReturnEmptyOptionalWhenSecretNotFound() {
         String nonExistentKey = "nonExistentKey";
         Optional<SecretDTO> optionalSecretDTO = secretsProviderVault.get(nonExistentKey);
 
         assertNotNull(optionalSecretDTO);
         assertTrue(optionalSecretDTO.isEmpty());
+    }
+
+    @Test
+    void shouldUpdatePathSuccess() {
+        String newPath = "secret/data/newTest";
+        secretsProviderVault.updatePath(newPath);
+        vaultTemplate.write(newPath, Map.of("data", Map.of(key, secretValue)));
+
+        Optional<SecretDTO> optionalSecretDTO = secretsProviderVault.get(key);
+
+        assertNotNull(optionalSecretDTO);
+        assertTrue(optionalSecretDTO.isPresent());
+        assertEquals(JsonUtils.convertSecretValueToJson(secretValue), optionalSecretDTO.get().value());
+
     }
 
     @SneakyThrows

--- a/src/test/java/io/github/open_source_lfernandes/spring_secret_starter/utils/faker/Credential.java
+++ b/src/test/java/io/github/open_source_lfernandes/spring_secret_starter/utils/faker/Credential.java
@@ -1,0 +1,15 @@
+package io.github.open_source_lfernandes.spring_secret_starter.utils.faker;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Credential implements Serializable {
+    String username;
+    String password;
+}


### PR DESCRIPTION
This pull request introduces a new feature for type conversion when retrieving secrets, along with improvements to the codebase and additional test coverage. The most significant changes include updates to the `SecretsManagerService` to support type conversion, enhancements to the configuration and error handling, and new tests to ensure the functionality works as expected.

### New Feature: Type Conversion for Secrets
* Added a new method `get(Origin origin, String key, Class<T> type)` to `SecretsManagerService` for retrieving secrets with type conversion using `ObjectMapper`. This method ensures seamless integration by converting secret values to the desired type.
* Updated the `SecretsManagerServiceAutoConfiguration` to include `ObjectMapper` as a dependency for `SecretsManagerService`. [[1]](diffhunk://#diff-45176d6288616c73ba5003afc8155f165cbf1a8f61f1a52f9825495e130b7d55R28-R35) [[2]](diffhunk://#diff-45176d6288616c73ba5003afc8155f165cbf1a8f61f1a52f9825495e130b7d55L41-R46)
* Enhanced the README with documentation and examples on retrieving secrets with type conversion. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R205-R237)

### Codebase Enhancements
* Applied `@FieldDefaults` and `@Slf4j` annotations to `SecretsManagerService` to enforce immutability and improve logging.
* Added a new error message `TYPE_CANNOT_BE_NULL` to the `Messages` enum for better error handling when the type parameter is null.

### Test Coverage Improvements
* Added a new test in `SecretsManagerServiceTest` to verify the type conversion functionality when retrieving secrets.
* Moved the `Credential` class to a reusable utility package (`utils.faker`) for consistent test data representation across tests. [[1]](diffhunk://#diff-846a2a47d0633d23086576d593dacdf638e004b04bd6d5100ad4f45ca81fe65fL90-L95) [[2]](diffhunk://#diff-5b48f9c1d13af6ca6b5595ec939899ab7b307196cdbc502efb228b3a4168848eR1-R15)
* Added a test in `SecretsProviderVaultTest` to verify the ability to update the path and retrieve secrets successfully.